### PR TITLE
fix: update command to run version bump script in CI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Bump version
         id: bump-version
         run: |
-          python scripts/bump_version.py ${{ steps.bump-type.outputs.type }}
+          uv run python scripts/bump_version.py ${{ steps.bump-type.outputs.type }}
 
       # Clean any build artifacts that might be present
       - name: Clean build artifacts


### PR DESCRIPTION
- Changed the command to execute the version bump script from `python` to `uv run python`, ensuring compatibility with the updated CI environment.